### PR TITLE
lock development golang version

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ _idea/
 
 # OS Files
 .DS_Store
+
+# Nix
+.direnv/
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v0.1.4] - 2025-03-16
+
+Update development version of golang to 1.23.
+
+
 ## [v0.1.3] - 2023-02-13
 
 Remove the RWMutex from the resources.go template.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1731603435,
+        "narHash": "sha256-CqCX4JG7UiHvkrBTpYC3wcEurvbtTADLbo3Ns2CEoL8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8b27c1239e5c421a2bbc2c65d52e4a6fbf2ff296",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "24.11",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,39 @@
+{
+  description = "Good development environment";
+
+  inputs.nixpkgs.url = "nixpkgs/24.11";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+          {
+            devShell = pkgs.mkShell {
+              shellHook = ''
+                set -a
+                source .env 2>/dev/null || echo "no .env file found"
+                set +a
+              '';
+              buildInputs = with pkgs; [
+                go
+                gopls
+                gops
+                gotests
+                delve
+                go-tools
+                errcheck
+                reftools
+                revive
+                gomodifytags
+                gotags
+                impl
+                go-motion
+                iferr
+              ];
+            };
+          }
+    );
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.16
 
 require (
 	github.com/pelletier/go-toml v1.9.1
-	github.com/rur/treetop v0.4.1
+	github.com/rur/treetop v0.4.1 // indirect
 	golang.org/x/mod v0.5.0
 )


### PR DESCRIPTION
Just some housekeeping, run against a newer version of golang and add some nix goodness to fix the development environment.

Release as a new version to just clear the pipes!